### PR TITLE
Fix wrong "source ww" command report.

### DIFF
--- a/ww
+++ b/ww
@@ -49,7 +49,7 @@ create() {
   echo "# For example, export ESSS_DEBUG=python could be done." >> "$ACTIVATE_SCRIPT"
   echo "" >> "$ACTIVATE_SCRIPT"
 
-  echo "Workspace created. Run \"source ww ${_NEW_WORKSPACE}\" to activate."
+  echo "Workspace created. Run \"source ww ${1}\" to activate."
 }
 
 


### PR DESCRIPTION
On Linux, after creating a new workspace `1` for example, `ww` would
mistakenly report:

> Workspace created. Run "source ww /home/user/w/1" to activate.

When, in fact, the command should be `source ww 1`. This is because
`_NEW_WORKSPACE` variable used on the related `echo` command is the
entire workspace path (`/home/user/w/1` in this case), when the correct
variable to be used is the function argument (`$1`), which holds the
workspace name/number.
