### PR TITLE
Fix workspace creation when a parent dir doesn't exist

### DIFF
--- a/ww
+++ b/ww
@@ -35,7 +35,6 @@ create() {
 
   _NEW_WORKSPACE="${WW_DEFAULT_PATH}/${1}"
 
-  mkdir -p "${_NEW_WORKSPACE}"
   mkdir -p "${_NEW_WORKSPACE}/${WW_PROJECTS_SUBDIR}"
 
   CONDA_ROOT=$(conda info --root)

--- a/ww
+++ b/ww
@@ -34,9 +34,9 @@ create() {
   fi
 
   _NEW_WORKSPACE="${WW_DEFAULT_PATH}/${1}"
-  
-  mkdir "$_NEW_WORKSPACE"
-  mkdir "${_NEW_WORKSPACE}/${WW_PROJECTS_SUBDIR}"
+
+  mkdir -p "${_NEW_WORKSPACE}"
+  mkdir -p "${_NEW_WORKSPACE}/${WW_PROJECTS_SUBDIR}"
 
   CONDA_ROOT=$(conda info --root)
   cp "${CONDA_ROOT}/.condarc" "${_NEW_WORKSPACE}/.condarc"


### PR DESCRIPTION
On the very first call of `ww` on a system, it is possible that
`/home/user/w` doesn't exist, thus failing to create a workspace `1` as
`mkdir /home/user/w/1` would fail. In that case, adding `-p` flag to
`mkdir` call solves this issue by creating the entire path whenever a
parent directory doesn't exist (in this case, creating `/home/user/w`
before attempting to create `/home/user/w/1`).
