### PR TITLE
Add way to activate a workspace on current path tree

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,22 @@
+name: build
+
+on:
+  push:
+    branches:
+      - master
+
+  pull_request:
+
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run tests
+        run: ./test_ww

--- a/README.md
+++ b/README.md
@@ -84,11 +84,24 @@ ww <workspace_name>
 
 #### Linux
 
-On `Linux` you need to `source` the workspace. Jus run:
+On `Linux` you need to `source` the workspace. Just run:
 
 ```
 source ww <workspace_name>
 ```
+
+##### Activate current
+
+It is also possible to activate a workspace from a subdir of a workspace root. If the cwd is at <workspace_name>/Projects/myproject for example, just run:
+
+```
+source ww .
+```
+
+The `<workspace_name>` will be activated without navigating to the workspace root folder. The cwd will still be at `<workspace_name>/Projects/myproject`.
+
+Note: This is a Linux-Only feature. 
+
 
 ### Get active workspace information 
 

--- a/test_ww
+++ b/test_ww
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+assert_equal() {
+    if [ $1 != $2 ]; then
+        errorOut "Assertion failed: $1 is not equal to $2'"
+    fi
+}
+
+test_can_activate_workspace() {
+    echo ""
+    echo "Testing ${FUNCNAME[0]}"
+    echo ""
+
+    local test_dir=$(pwd)
+
+    mkdir $test_dir/temp-ww-workdir
+    export WW_DEFAULT_PATH=$test_dir/temp-ww-workdir
+
+    $test_dir/ww -c ws1
+    source ./ww ws1
+    
+    # check that the correct workspace was activated
+    assert_equal $WW_CURRENT_WORKSPACE ws1
+    assert_equal $CONDA_ENVS_PATH $test_dir/temp-ww-workdir/ws1/envs
+
+    cd $test_dir
+    rm -rf temp-ww-workdir
+}
+
+
+test_can_activate_current() {
+    echo ""
+    echo "Testing ${FUNCNAME[0]}"
+    echo ""
+    local test_dir=$(pwd)
+
+    mkdir $test_dir/temp-ww-workdir
+    export WW_DEFAULT_PATH=$test_dir/temp-ww-workdir
+    
+    $test_dir/ww -c ws2
+
+    cd ./temp-ww-workdir/ws2/Projects
+    
+    local cwd_before=$(pwd)
+    source $test_dir/ww .
+
+    # check that the current work dir was not changed
+    local current_dir=$(pwd)
+    assert_equal $current_dir $cwd_before
+
+    # check that the correct workspace was activated
+    assert_equal $WW_CURRENT_WORKSPACE ws2
+    assert_equal $CONDA_ENVS_PATH $test_dir/temp-ww-workdir/ws2/envs
+
+    cd $test_dir
+    rm -rf temp-ww-workdir
+}
+
+echo "Testing file test_ww"
+test_can_activate_workspace
+test_can_activate_current
+echo "Success"

--- a/ww
+++ b/ww
@@ -17,6 +17,9 @@ activate() {
   fi
 
   local workspace="${1}"
+  local skip_navigation="${2}"
+
+  export WW_CURRENT_WORKSPACE=$workspace
 
   # Checks it provided workspace fits as a relative path.
   # If not, then consider it an absolute path.
@@ -25,14 +28,26 @@ activate() {
   fi
 
   echo Activating $workspace...
-  source "${workspace}/ww_activate.sh"
-  cd "${workspace}/${WW_PROJECTS_SUBDIR}"
+  if [[ -z $skip_navigation ]]; then
+    cd "${workspace}/${WW_PROJECTS_SUBDIR}"
+  fi
   export CONDA_ENVS_PATH="${workspace}/envs"
   export CONDARC="${workspace}/.condarc"
   if [[ -n $WW_CONDA_PKGS_PATH ]]; then
     export CONDA_PKGS_PATH=$WW_CONDA_PKGS_PATH
   fi
+}
 
+activate_current() {
+  if [ -z "$sourced" ]; then
+    errorOut "use 'source ww .'"
+  fi
+
+  local current_path=$(pwd)
+  local path_from_ww_root=${current_path#*$WW_DEFAULT_PATH/};
+  local workspace_name=${path_from_ww_root%%/*};
+
+  activate $workspace_name 1
 }
 
 create() {
@@ -88,6 +103,11 @@ help() {
   Examples:
   $0 -c 99
   source $0 9
+
+  # enable current workspace root from inside folder 
+  $0 -c wp1
+  cd $WW_DEFAULT_PATH/wp1/Projects
+  source $0 .
   "
   echo "$_docs"
 
@@ -121,6 +141,8 @@ do
       ;;
     -h ) help
          exit
+      ;;
+    . ) activate_current
       ;;
     *  ) activate $1
       ;;


### PR DESCRIPTION
Useful when opening the terminal from inside a workspace subfolder (a project folder for example). Running the command `source ww .` will activate the current workspace and keep the cwd.  