### PR TITLE
Allow to set a folder as ww root on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,9 @@ ww <workspace_name>
 
 On `Linux` you need to `source` the workspace. Just run:
 
-```
+```bash
 source ww <workspace_name>
+cd <workspace-path>  # Unlike Windows, in Linux you must CD into workspace manually.
 ```
 
 ##### Activate current

--- a/README.md
+++ b/README.md
@@ -16,28 +16,17 @@ conda install ww
 
 ### Change default workspaces location
 
-`ww` will create new workspaces on a default location, but that location must exist. If one does not, you can either create it or tell `ww` you want it to create workspaces on a different (and existent) location.
+`ww` will create new workspaces on a default location, but that location must exist. If one does not, you can either create it or tell `ww` you want it to create workspaces on a different (and existent) location. The default location on Windows is the `W:\` and on Linux is `~/w`.
 
-#### Windows
+To change the default location, set the environment variable `WW_DEFAULT_PATH`:
 
-The default location for workspace creation is the root of the volume `W:`. 
-To change default workspace location you need to override the environment variable `WW_DEFAULT_VOLUMES`
+Windows:
 
-```
-setx WW_DEFAULT_VOLUMES <VOLUME>
-set WW_DEFAULT_VOLUMES=<VOLUME>
-```
+    set WW_DEFAULT_PATH=<DIR>
 
-The `setx` command will persist the change between sessions while the `set` command will make the change for the current session.
+Linux:
 
-#### Linux
-
-On linux the default location for workspace creation is the folder at `~/w`. 
-To change default workspace location you need to override the environment variable `WW_DEFAULT_PATH`
-
-```
-export WW_DEFAULT_PATH=<path>
-```
+    export WW_DEFAULT_PATH=<DIR>
 
 
 ## Folder structure of a workspace
@@ -97,11 +86,6 @@ It is also possible to activate a workspace from a subdir of a workspace root. I
 ```
 source ww .
 ```
-
-The `<workspace_name>` will be activated without navigating to the workspace root folder. The cwd will still be at `<workspace_name>/Projects/myproject`.
-
-Note: This is a Linux-Only feature. 
-
 
 ### Get active workspace information 
 

--- a/ww
+++ b/ww
@@ -95,10 +95,10 @@ help() {
 
   You can configure the following environment variables, if needed:
 
-  WW_DEFAULT_PATH:  Volumes to be used in ww.
+  WW_DEFAULT_PATH:  Folder where workspaces will be stored.
          Default = ~/w
          Current = $WW_DEFAULT_PATH
-  WW_PROJECTS_SUBDIR:  Subdirectory of workspace where projects are cloned.
+  WW_PROJECTS_SUBDIR:  Subdirectory of the workspace to store the source code.
          Default = Projects
          Current = $WW_PROJECTS_SUBDIR
   WW_CONDA_PKGS_PATH:   If defined, will set location where conda packages will be cached. Otherwise


### PR DESCRIPTION
Until now, the Windows version of ww only supported volumes as workspaces root folder (setting anything other than a drive letter on Windows lead to failure when activating workspaces).

This change creates the variables %WW_DEFAULT_PATH% to set full path as workspace root on Winodws (this option already exits in the Linux version).